### PR TITLE
Add helper to generate a ManagedResource for a partial cluster-scoped object

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -7,7 +7,7 @@
       "name": "Espejote",
       "slug": "espejote",
       "parameter_key": "espejote",
-      "test_cases": "defaults",
+      "test_cases": "defaults resources",
       "add_lib": "n",
       "add_pp": "n",
       "add_golden": "y",

--- a/.cruft.json
+++ b/.cruft.json
@@ -7,7 +7,7 @@
       "name": "Espejote",
       "slug": "espejote",
       "parameter_key": "espejote",
-      "test_cases": "defaults resources",
+      "test_cases": "defaults resources lib",
       "add_lib": "n",
       "add_pp": "n",
       "add_golden": "y",

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,6 +34,7 @@ jobs:
         instance:
           - defaults
           - resources
+          - lib
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -50,6 +51,7 @@ jobs:
         instance:
           - defaults
           - resources
+          - lib
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -50,4 +50,4 @@ KUBENT_IMAGE    ?= ghcr.io/doitintl/kube-no-trouble:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 
 instance ?= defaults
-test_instances = tests/defaults.yml tests/resources.yml
+test_instances = tests/defaults.yml tests/resources.yml tests/lib.yml

--- a/lib/espejote.libsonnet
+++ b/lib/espejote.libsonnet
@@ -66,6 +66,23 @@ local managedResource(name, namespace) = {
   },
 };
 
+// Guesses the resource from the resource kind.
+// Inspired by https://github.com/kubernetes/apimachinery/blob/954960919938450fb6d06065f4bf92855dda73fd/pkg/api/meta/restmapper.go#L126
+local guessResourceFromKind(kind) =
+  local singular = std.asciiLower(kind);
+  local irregular = {
+    endpoints: 'endpoints',
+  };
+
+  if std.objectHas(irregular, singular) then
+    irregular[singular]
+  else if std.endsWith(singular, 's') || std.endsWith(singular, 'ch') || std.endsWith(singular, 'x') then
+    singular + 'es'
+  else if std.endsWith(singular, 'y') then
+    std.substr(singular, 0, std.length(singular) - 1) + 'ies'
+  else
+    singular + 's';
+
 
 local generateRolesForManagedResource(manifest) =
   local manifestMeta = std.get(manifest, 'metadata', {});
@@ -85,23 +102,6 @@ local generateRolesForManagedResource(manifest) =
       ''
     else
       parts[0];
-
-  // Guesses the resource from the resource kind.
-  // Inspired by https://github.com/kubernetes/apimachinery/blob/954960919938450fb6d06065f4bf92855dda73fd/pkg/api/meta/restmapper.go#L126
-  local guessResourceFromKind(kind) =
-    local singular = std.asciiLower(kind);
-    local irregular = {
-      endpoints: 'endpoints',
-    };
-
-    if std.objectHas(irregular, singular) then
-      irregular[singular]
-    else if std.endsWith(singular, 's') || std.endsWith(singular, 'ch') || std.endsWith(singular, 'x') then
-      singular + 'es'
-    else if std.endsWith(singular, 'y') then
-      std.substr(singular, 0, std.length(singular) - 1) + 'ies'
-    else
-      singular + 's';
 
   local roleFromResource(suffixes, resource) = {
     local resourceNs = std.get(resource, 'namespace', manifestMeta.namespace),
@@ -250,6 +250,91 @@ local createContextRBAC(manifest) =
     roles
   );
 
+/**
+ * \brief Generate a managed resource and associated service account and RBAC
+ *        for managing a partial cluster-scoped object.
+ *
+ * This function generates a service account, RBAC and a a managed resource to
+ * apply the partial `obj`. The function expects that the provided `obj` has
+ * fields `apiVersion`, `kind` and `metadata.name`. Additionally the function
+ * expects those fields to uniquely identify a cluster-scoped target object.
+ *
+ * The function tries to guess the resource name for RBAC from the provided
+ * `obj.kind`. The resource name can be provided explicitly via parameter
+ * `resource` if the guessed resource is incorrect.
+ *
+ * \mr_namespace the namespace for the managed resource (and service account)
+ * \obj the partial manifest to apply. The function expects that this object
+ *      has fields `apiVersion`, `kind` and `metadata.name` to identify a
+ *      target resource in the cluster.
+ * \resource overrides the guessed resource from the provided `obj.kind`
+ * \mgr_name overrides the generated manager name (for the service account
+ *           etc.). When this is given, it's the caller's responsibility to
+ *           ensure that there are no name conflicts in the `mr_namespace`.
+ *
+ * \return A list containing the manifests required to apply the partial
+ *         config to the target object.
+ */
+local clusterScopedObject(mr_namespace, obj, resource=null, mgr_name=null) =
+  local apiVersion = obj.apiVersion;
+  local kind = obj.kind;
+  local name = obj.metadata.name;
+
+  local apigrp =
+    local api = std.split(apiVersion, '/');
+    if std.length(api) > 1 then api[0] else '';
+  local res = if resource != null then resource else guessResourceFromKind(kind);
+  local mgrName = if mgr_name != null then
+    mgr_name
+  else
+    '%s-%s-%s-manager' % [ std.strReplace(apigrp, '.', '-'), res, name ];
+  local sa =
+    {
+      apiVersion: 'v1',
+      kind: 'ServiceAccount',
+      metadata+: {
+        name: mgrName,
+        namespace: mr_namespace,
+      },
+    };
+  local clusterrole = {
+    apiVersion: 'rbac.authorization.k8s.io/v1',
+    kind: 'ClusterRole',
+    metadata: {
+      name: '%s:%s' % [ mr_namespace, mgrName ],
+    },
+    rules: [
+      {
+        apiGroups: [ apigrp ],
+        resources: [ res ],
+        resourceNames: [ name ],
+        verbs: [ '*' ],
+      },
+    ],
+  };
+  [ sa, clusterrole ] +
+  bindRoles(mr_namespace, sa.metadata.name, [ clusterrole ]) +
+  [
+    managedResource(mgrName, mr_namespace) {
+      spec: {
+        applyOptions: { force: true },
+        serviceAccountRef: { name: sa.metadata.name },
+        triggers: [
+          {
+            name: 'target',
+            watchResource: {
+              apiVersion: apiVersion,
+              kind: kind,
+              name: name,
+            },
+          },
+        ],
+        template: std.manifestJson(obj),
+      },
+    },
+  ];
+
+
 {
   admission: admission,
   jsonnetLibrary: jsonnetLibrary,
@@ -257,4 +342,5 @@ local createContextRBAC(manifest) =
 
   serviceAccountNameFromManagedResource: serviceAccountNameFromManagedResource,
   createContextRBAC: createContextRBAC,
+  clusterScopedObject: clusterScopedObject,
 }

--- a/tests/golden/lib/espejote/apps/espejote.yaml
+++ b/tests/golden/lib/espejote/apps/espejote.yaml
@@ -1,0 +1,4 @@
+spec:
+  syncPolicy:
+    syncOptions:
+      - ServerSideApply=true

--- a/tests/golden/lib/espejote/espejote/00_namespace.yaml
+++ b/tests/golden/lib/espejote/espejote/00_namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/name: syn-espejote
+    name: syn-espejote
+  name: syn-espejote

--- a/tests/golden/lib/espejote/espejote/10_kustomize/crd/apiextensions.k8s.io_v1_customresourcedefinition_admissions.espejote.io.yaml
+++ b/tests/golden/lib/espejote/espejote/10_kustomize/crd/apiextensions.k8s.io_v1_customresourcedefinition_admissions.espejote.io.yaml
@@ -1,0 +1,304 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: admissions.espejote.io
+spec:
+  group: espejote.io
+  names:
+    kind: Admission
+    listKind: AdmissionList
+    plural: admissions
+    singular: admission
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.status
+      name: Status
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          Admission is the Schema for the Admissions API.
+          Admission currently fully relies on cert-manager for certificate management and webhook certificate injection.
+          See the kustomize overlays for more information.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AdmissionSpec defines the desired state of Admission.
+            properties:
+              mutating:
+                description: Mutating defines if the Admission should create a MutatingWebhookConfiguration
+                  or a ValidatingWebhookConfiguration.
+                type: boolean
+              template:
+                description: |-
+                  Template contains the Jsonnet code to decide the admission result.
+                  Admission responses should be created using the `espejote.libsonnet` library.
+                  `esp.ALPHA.admission.allowed("Nice job!")`, `esp.ALPHA.admission.denied("Bad job!")`, `esp.ALPHA.admission.patched("added user annotation", [jsonPatchOp("add", "/metadata/annotations/user", "tom")])` are examples of valid responses.
+                  The template can reference JsonnetLibrary objects by importing them.
+                  JsonnetLibrary objects have the following structure:
+                  - "espejote.libsonnet": The built in library for accessing the context and trigger information.
+                  - "lib/<NAME>/<KEY>" libraries in the shared library namespace. The name corresponds to the name of the JsonnetLibrary object and the key to the key in the data field.
+                    The namespace is configured at controller startup and normally points to the namespace of the controller.
+                  - "<NAME>/<KEY>" libraries in the same namespace as the Admission. The name corresponds to the name of the JsonnetLibrary object and the key to the key in the data field.
+                type: string
+              webhookConfiguration:
+                description: |-
+                  WebhookConfiguration defines the configuration for the Admission webhook.
+                  Allows fine grained control over what is forwarded to the webhook.
+                  Note that Admission enforces namespace isolation. The namespaceSelector field is set to the namespace of the Admission and can't be overridden.
+                  There will be a ClusterAdmission in the future to allow for cluster wide admission control.
+                properties:
+                  failurePolicy:
+                    description: |-
+                      FailurePolicy defines how unrecognized errors from the admission endpoint are handled -
+                      allowed values are Ignore or Fail. Defaults to Fail.
+                    type: string
+                  matchConditions:
+                    description: |-
+                      MatchConditions is a list of conditions that must be met for a request to be sent to this
+                      webhook. Match conditions filter requests that have already been matched by the rules,
+                      namespaceSelector, and objectSelector. An empty list of matchConditions matches all requests.
+                      There are a maximum of 64 match conditions allowed.
+
+                      The exact matching logic is (in order):
+                        1. If ANY matchCondition evaluates to FALSE, the webhook is skipped.
+                        2. If ALL matchConditions evaluate to TRUE, the webhook is called.
+                        3. If any matchCondition evaluates to an error (but none are FALSE):
+                           - If failurePolicy=Fail, reject the request
+                           - If failurePolicy=Ignore, the error is ignored and the webhook is skipped
+                    items:
+                      description: MatchCondition represents a condition which must
+                        by fulfilled for a request to be sent to a webhook.
+                      properties:
+                        expression:
+                          description: |-
+                            Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
+                            CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+                            'object' - The object from the incoming request. The value is null for DELETE requests.
+                            'oldObject' - The existing object. The value is null for CREATE requests.
+                            'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).
+                            'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+                              See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+                            'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+                              request resource.
+                            Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                            Required.
+                          type: string
+                        name:
+                          description: |-
+                            Name is an identifier for this match condition, used for strategic merging of MatchConditions,
+                            as well as providing an identifier for logging purposes. A good name should be descriptive of
+                            the associated expression.
+                            Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and
+                            must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or
+                            '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an
+                            optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+                            Required.
+                          type: string
+                      required:
+                      - expression
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  matchPolicy:
+                    description: |-
+                      matchPolicy defines how the "rules" list is used to match incoming requests.
+                      Allowed values are "Exact" or "Equivalent".
+
+                      - Exact: match a request only if it exactly matches a specified rule.
+                      For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1,
+                      but "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`,
+                      a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the webhook.
+
+                      - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version.
+                      For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1,
+                      and "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`,
+                      a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the webhook.
+
+                      Defaults to "Equivalent"
+                    type: string
+                  objectSelector:
+                    description: |-
+                      ObjectSelector decides whether to run the webhook based on if the
+                      object has matching labels. objectSelector is evaluated against both
+                      the oldObject and newObject that would be sent to the webhook, and
+                      is considered to match if either object matches the selector. A null
+                      object (oldObject in the case of create, or newObject in the case of
+                      delete) or an object that cannot have labels (like a
+                      DeploymentRollback or a PodProxyOptions object) is not considered to
+                      match.
+                      Use the object selector only if the webhook is opt-in, because end
+                      users may skip the admission webhook by setting the labels.
+                      Default to the empty LabelSelector, which matches everything.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  reinvocationPolicy:
+                    description: |-
+                      reinvocationPolicy indicates whether this webhook should be called multiple times as part of a single admission evaluation.
+                      Allowed values are "Never" and "IfNeeded".
+
+                      Never: the webhook will not be called more than once in a single admission evaluation.
+
+                      IfNeeded: the webhook will be called at least one additional time as part of the admission evaluation
+                      if the object being admitted is modified by other admission plugins after the initial webhook call.
+                      Webhooks that specify this option *must* be idempotent, able to process objects they previously admitted.
+                      Note:
+                      * the number of additional invocations is not guaranteed to be exactly one.
+                      * if additional invocations result in further modifications to the object, webhooks are not guaranteed to be invoked again.
+                      * webhooks that use this option may be reordered to minimize the number of additional invocations.
+                      * to validate an object after all mutations are guaranteed complete, use a validating admission webhook instead.
+
+                      Defaults to "Never".
+                    type: string
+                  rules:
+                    description: |-
+                      Rules describes what operations on what resources/subresources the webhook cares about.
+                      The webhook cares about an operation if it matches _any_ Rule.
+                      However, in order to prevent ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks
+                      from putting the cluster in a state which cannot be recovered from without completely
+                      disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called
+                      on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.
+                    items:
+                      description: |-
+                        RuleWithOperations is a tuple of Operations and Resources. It is recommended to make
+                        sure that all the tuple expansions are valid.
+                      properties:
+                        apiGroups:
+                          description: |-
+                            APIGroups is the API groups the resources belong to. '*' is all groups.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        apiVersions:
+                          description: |-
+                            APIVersions is the API versions the resources belong to. '*' is all versions.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        operations:
+                          description: |-
+                            Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or *
+                            for all of those operations and any future admission operations that are added.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            description: OperationType specifies an operation for
+                              a request.
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        resources:
+                          description: |-
+                            Resources is a list of resources this rule applies to.
+
+                            For example:
+                            'pods' means pods.
+                            'pods/log' means the log subresource of pods.
+                            '*' means all resources, but not subresources.
+                            'pods/*' means all subresources of pods.
+                            '*/scale' means all scale subresources.
+                            '*/*' means all resources and their subresources.
+
+                            If wildcard is present, the validation rule will ensure resources do not
+                            overlap with each other.
+
+                            Depending on the enclosing object, subresources might not be allowed.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        scope:
+                          description: |-
+                            scope specifies the scope of this rule.
+                            Valid values are "Cluster", "Namespaced", and "*"
+                            "Cluster" means that only cluster-scoped resources will match this rule.
+                            Namespace API objects are cluster-scoped.
+                            "Namespaced" means that only namespaced resources will match this rule.
+                            "*" means that there are no scope restrictions.
+                            Subresources match the scope of their parent resource.
+                            Default is "*".
+                          type: string
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/tests/golden/lib/espejote/espejote/10_kustomize/crd/apiextensions.k8s.io_v1_customresourcedefinition_jsonnetlibraries.espejote.io.yaml
+++ b/tests/golden/lib/espejote/espejote/10_kustomize/crd/apiextensions.k8s.io_v1_customresourcedefinition_jsonnetlibraries.espejote.io.yaml
@@ -1,0 +1,57 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: jsonnetlibraries.espejote.io
+spec:
+  group: espejote.io
+  names:
+    kind: JsonnetLibrary
+    listKind: JsonnetLibraryList
+    plural: jsonnetlibraries
+    singular: jsonnetlibrary
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: JsonnetLibrary is the Schema for the jsonnetlibraries API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: JsonnetLibrarySpec defines the desired state of JsonnetLibrary.
+            properties:
+              data:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Data is a map of Jsonnet library files.
+                  The key is the file name and the value is the file content.
+                  JsonnetLibraries can use relative imports as follows:
+
+                  - `./KEY` and `KEY` resolve to the same JsonnetLibrary manifest.
+                  - `./NAME/KEY` and `NAME/KEY` resolve to the same namespace (shared/local).
+                  - `espejote.libsonnet` always resolves to the built-in library.
+                  - `./espejote.libsonnet ` resolves to the `espejote.libsonnet` key in the same library.
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/tests/golden/lib/espejote/espejote/10_kustomize/crd/apiextensions.k8s.io_v1_customresourcedefinition_managedresources.espejote.io.yaml
+++ b/tests/golden/lib/espejote/espejote/10_kustomize/crd/apiextensions.k8s.io_v1_customresourcedefinition_managedresources.espejote.io.yaml
@@ -1,0 +1,405 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: managedresources.espejote.io
+spec:
+  group: espejote.io
+  names:
+    kind: ManagedResource
+    listKind: ManagedResourceList
+    plural: managedresources
+    singular: managedresource
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.status
+      name: Status
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ManagedResource is the Schema for the ManagedResources API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ManagedResourceSpec defines the desired state of ManagedResource
+            properties:
+              applyOptions:
+                description: ApplyOptions defines the options for applying the ManagedResource
+                properties:
+                  fieldManager:
+                    description: |-
+                      FieldManager is the field manager to use when applying the ManagedResource
+                      If not set, the field manager is set to the name of the resource with `managed-resource` prefix
+                    type: string
+                  fieldValidation:
+                    default: Strict
+                    description: |-
+                      fieldValidation instructs the managed resource on how to handle
+                      objects containing unknown or duplicate fields. Valid values are:
+                      - Ignore: This will ignore any unknown fields that are silently
+                      dropped from the object, and will ignore all but the last duplicate
+                      field that the decoder encounters.
+                      Note that Jsonnet won't allow you to add duplicate fields to an object
+                      and most unregistered fields will error out in the server-side apply
+                      request, even with this option set.
+                      - Strict: This will fail the request with a BadRequest error if
+                      any unknown fields would be dropped from the object, or if any
+                      duplicate fields are present. The error returned will contain
+                      all unknown and duplicate fields encountered.
+                      Defaults to "Strict".
+                    enum:
+                    - Ignore
+                    - Strict
+                    type: string
+                  force:
+                    default: false
+                    description: |-
+                      Force is going to "force" Apply requests. It means user will
+                      re-acquire conflicting fields owned by other people.
+                    type: boolean
+                type: object
+              context:
+                description: Context defines the context for the ManagedResource
+                items:
+                  properties:
+                    name:
+                      description: Name is the name of the context definition. The
+                        context can be referenced in the template by this name.
+                      minLength: 1
+                      type: string
+                    resource:
+                      description: |-
+                        Resource defines the resource that should be added to the context.
+                        Adds a list of zero or more resources to the context.
+                      properties:
+                        apiVersion:
+                          description: |-
+                            APIVersion of the resource that should be added to the context.
+                            The APIVersion can be in the form "group/version" or "version".
+                          type: string
+                        ignoreNames:
+                          description: |-
+                            IgnoreNames can be used to filter the resources that should be added to the context.
+                            This is considered experimental and might be removed in the future.
+                            The filtering is done on the controller side and might not be as efficient as the LabelSelector.
+                            Filtered objects are dropped before any caching or processing.
+                          items:
+                            type: string
+                          type: array
+                        kind:
+                          description: Kind of the resource that should be added to
+                            the context.
+                          type: string
+                        labelSelector:
+                          description: |-
+                            LabelSelector can be used to filter the resources that should be added to the context.
+                            This is efficiently done by the Kubernetes API server
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        matchNames:
+                          description: |-
+                            MatchNames can be used to filter the resources that should be added to the context.
+                            This is considered experimental and might be removed in the future.
+                            The filtering is done on the controller side and might not be as efficient as the LabelSelector.
+                            Filtered objects are dropped before any caching or processing.
+                          items:
+                            type: string
+                          type: array
+                        name:
+                          description: |-
+                            Name of the resource that should be added to the context.
+                            If not set, all resources of the specified Kind are added to the context.
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace for the resources that should be added to the context.
+                            If not set, the namespace of the ManagedResource is used.
+                            Can be set to empty string to add all namespaces.
+                          type: string
+                        stripManagedFields:
+                          description: |-
+                            StripManagedFields removes the managedFields from the watched resource.
+                            managedFields are not used in Espejote and if the template does not use them, they can be removed to significantly reduce the size of cached objects.
+                            Defaults to true if not set.
+                          type: boolean
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              serviceAccountRef:
+                default:
+                  name: default
+                description: |-
+                  ServiceAccountRef is the service account this managed resource runs as.
+                  The service account must have the necessary permissions to manage the resources referenced in the template.
+                  If not set, the namespace's default service account is used.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              template:
+                description: |-
+                  Template defines the template for the ManagedResource
+                  The template is rendered using Jsonnet and the result is applied to the cluster.
+                  The template can reference the context and trigger information.
+                  All access to injected data should be done through the `espejote.libsonnet` import.
+                  The template can reference JsonnetLibrary objects by importing them.
+                  JsonnetLibrary objects have the following structure:
+                  - "espejote.libsonnet": The built in library for accessing the context and trigger information.
+                  - "lib/<NAME>/<KEY>" libraries in the shared library namespace. The name corresponds to the name of the JsonnetLibrary object and the key to the key in the data field.
+                    The namespace is configured at controller startup and normally points to the namespace of the controller.
+                  - "<NAME>/<KEY>" libraries in the same namespace as the ManagedResource. The name corresponds to the name of the JsonnetLibrary object and the key to the key in the data field.
+                  The template can return a single object, a list of objects, or null. Everything else is considered an error.
+                  Namespaced objects default to the namespace of the ManagedResource.
+                type: string
+              triggers:
+                description: |-
+                  Triggers define the resources that trigger the reconciliation of the ManagedResource
+                  Trigger information will be injected when rendering the template.
+                  This can be used to only partially render the template based on the trigger.
+                items:
+                  properties:
+                    interval:
+                      description: Interval defines the interval at which the ManagedResource
+                        should be reconciled.
+                      format: duration
+                      type: string
+                    name:
+                      description: Name is the name of the trigger. The trigger can
+                        be referenced in the template by this name.
+                      minLength: 1
+                      type: string
+                    watchContextResource:
+                      description: |-
+                        WatchContextResource works the same as WatchResource, but it uses and already existing context resource.
+                        This is useful when you require both full (when the template changes) and partial (a context resource changes) reconciliation of the same resource.
+                        Check the example below. Both a context resource and a trigger are defined. If the trigger is not known in the template all network policies are reconciled.
+                        If the trigger is known, only the network policies that match the trigger are reconciled. Using `watchContextResource` allows this without having to define the same resource again.
+
+                          apiVersion: espejote.io/v1alpha1
+                          kind: ManagedResource
+                          metadata:
+                            name: naemspace-default-netpol
+                            annotations:
+                              description: |
+                                Injects a default network policy into every namespace not labeled `netpol.example.com/no-default`.
+                          spec:
+                            context:
+                            - name: namespaces
+                              resource:
+                                apiVersion: v1
+                                kind: Namespace
+                                labelSelector:
+                                  matchExpressions:
+                                  - key: netpol.example.com/no-default
+                                    operator: DoesNotExist
+                            triggers:
+                            - name: namespace
+                              watchContextResource:
+                                name: namespaces
+                            template: |
+                              local esp = import 'espejote.libsonnet';
+
+                              local netpolForNs = function(ns) {
+                                [...]
+                              };
+
+                              if esp.triggerName() == 'namespace' then [
+                                netpolForNs(esp.triggerData().resource),
+                              ] else [
+                                netpolForNs(ns)
+                                for ns in esp.context().namespaces
+                              ]
+                      properties:
+                        name:
+                          description: Name is the name of the context definition
+                            used when creating this trigger.
+                          type: string
+                      type: object
+                    watchResource:
+                      description: |-
+                        WatchResource defines one or multiple resources that trigger the reconciliation of the ManagedResource.
+                        Resource information is injected when rendering the template and can be retrieved using `(import "espejote.libsonnet").getTrigger()`.
+                        `local esp = import "espejote.libsonnet"; esp.triggerType() == esp.TriggerTypeWatchResource` will be true if the render was triggered by a definition in this block.
+                      properties:
+                        apiVersion:
+                          description: |-
+                            APIVersion of the resource that should be watched.
+                            The APIVersion can be in the form "group/version" or "version".
+                          type: string
+                        ignoreNames:
+                          description: |-
+                            IgnoreNames can be used to filter the resources that should be watched.
+                            This is considered experimental and might be removed in the future.
+                            The filtering is done on the controller side and might not be as efficient as the LabelSelector.
+                            Filtered objects are dropped before any caching or processing.
+                          items:
+                            type: string
+                          type: array
+                        kind:
+                          description: Kind of the resource that should be watched.
+                          type: string
+                        labelSelector:
+                          description: |-
+                            LabelSelector can be used to filter the resources that should be watched.
+                            This is efficiently done by the Kubernetes API server
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        matchNames:
+                          description: |-
+                            MatchNames can be used to filter the resources that should be watched.
+                            This is considered experimental and might be removed in the future.
+                            The filtering is done on the controller side and might not be as efficient as the LabelSelector.
+                            Filtered objects are dropped before any caching or processing.
+                          items:
+                            type: string
+                          type: array
+                        name:
+                          description: |-
+                            Name of the resource that should be watched.
+                            If not set, all resources of the specified Kind are watched.
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace for the resources that should be watched.
+                            If not set, the namespace of the ManagedResource is used.
+                            Can be explicitly set to empty string to watch all namespaces.
+                          type: string
+                        stripManagedFields:
+                          description: |-
+                            StripManagedFields removes the managedFields from the watched resource.
+                            managedFields are not used in Espejote and if the template does not use them, they can be removed to significantly reduce the size of cached objects.
+                            Defaults to true if not set.
+                          type: boolean
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+            type: object
+          status:
+            description: ManagedResourceStatus defines the observed state of ManagedResource
+            properties:
+              status:
+                description: |-
+                  Status reports the last overall status of the ManagedResource
+                  More information can be found by inspecting the ManagedResource's events with either `kubectl describe` or `kubectl get events`.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/tests/golden/lib/espejote/espejote/10_kustomize/espejote/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_espejote-dynamic-webhook.yaml
+++ b/tests/golden/lib/espejote/espejote/10_kustomize/espejote/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_espejote-dynamic-webhook.yaml
@@ -1,0 +1,7 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: syn-espejote/espejote-serving-cert
+  name: espejote-dynamic-webhook
+webhooks: []

--- a/tests/golden/lib/espejote/espejote/10_kustomize/espejote/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_espejote-dynamic-webhook.yaml
+++ b/tests/golden/lib/espejote/espejote/10_kustomize/espejote/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_espejote-dynamic-webhook.yaml
@@ -1,0 +1,7 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: syn-espejote/espejote-serving-cert
+  name: espejote-dynamic-webhook
+webhooks: []

--- a/tests/golden/lib/espejote/espejote/10_kustomize/espejote/apps_v1_deployment_espejote-controller-manager.yaml
+++ b/tests/golden/lib/espejote/espejote/10_kustomize/espejote/apps_v1_deployment_espejote-controller-manager.yaml
@@ -1,0 +1,97 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: espejote
+    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: deployment
+    app.kubernetes.io/part-of: espejote
+    control-plane: controller-manager
+  name: espejote-controller-manager
+  namespace: syn-espejote
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        app.kubernetes.io/name: espejote
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - controller
+        - --metrics-bind-address=:8443
+        - --leader-elect
+        - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
+        - --dynamic-admission-webhook-port=443
+        - --metrics-cert-path=/tmp/k8s-metrics-server/metrics-certs
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: ghcr.io/vshn/espejote:v0.9.0
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: webhook-certs
+          readOnly: true
+        - mountPath: /tmp/k8s-metrics-server/metrics-certs
+          name: metrics-certs
+          readOnly: true
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: espejote-controller-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: webhook-certs
+        secret:
+          secretName: webhook-server-cert
+      - name: metrics-certs
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          - key: tls.crt
+            path: tls.crt
+          - key: tls.key
+            path: tls.key
+          optional: false
+          secretName: metrics-server-cert

--- a/tests/golden/lib/espejote/espejote/10_kustomize/espejote/cert-manager.io_v1_certificate_espejote-metrics-certs.yaml
+++ b/tests/golden/lib/espejote/espejote/10_kustomize/espejote/cert-manager.io_v1_certificate_espejote-metrics-certs.yaml
@@ -1,0 +1,16 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: espejote
+  name: espejote-metrics-certs
+  namespace: syn-espejote
+spec:
+  dnsNames:
+  - espejote-controller-manager-metrics-service.syn-espejote.svc
+  - espejote-controller-manager-metrics-service.syn-espejote.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: espejote-selfsigned-issuer
+  secretName: metrics-server-cert

--- a/tests/golden/lib/espejote/espejote/10_kustomize/espejote/cert-manager.io_v1_certificate_espejote-serving-cert.yaml
+++ b/tests/golden/lib/espejote/espejote/10_kustomize/espejote/cert-manager.io_v1_certificate_espejote-serving-cert.yaml
@@ -1,0 +1,16 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: espejote
+  name: espejote-serving-cert
+  namespace: syn-espejote
+spec:
+  dnsNames:
+  - espejote-webhook-service.syn-espejote.svc
+  - espejote-webhook-service.syn-espejote.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: espejote-selfsigned-issuer
+  secretName: webhook-server-cert

--- a/tests/golden/lib/espejote/espejote/10_kustomize/espejote/cert-manager.io_v1_issuer_espejote-selfsigned-issuer.yaml
+++ b/tests/golden/lib/espejote/espejote/10_kustomize/espejote/cert-manager.io_v1_issuer_espejote-selfsigned-issuer.yaml
@@ -1,0 +1,10 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: espejote
+  name: espejote-selfsigned-issuer
+  namespace: syn-espejote
+spec:
+  selfSigned: {}

--- a/tests/golden/lib/espejote/espejote/10_kustomize/espejote/monitoring.coreos.com_v1_servicemonitor_espejote-controller-manager-metrics-monitor.yaml
+++ b/tests/golden/lib/espejote/espejote/10_kustomize/espejote/monitoring.coreos.com_v1_servicemonitor_espejote-controller-manager-metrics-monitor.yaml
@@ -1,0 +1,36 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/created-by: espejote
+    app.kubernetes.io/instance: controller-manager-metrics-monitor
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: servicemonitor
+    app.kubernetes.io/part-of: espejote
+    control-plane: controller-manager
+  name: espejote-controller-manager-metrics-monitor
+  namespace: syn-espejote
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    path: /metrics
+    port: https
+    scheme: https
+    tlsConfig:
+      ca:
+        secret:
+          key: ca.crt
+          name: metrics-server-cert
+      cert:
+        secret:
+          key: tls.crt
+          name: metrics-server-cert
+      insecureSkipVerify: false
+      keySecret:
+        key: tls.key
+        name: metrics-server-cert
+      serverName: espejote-controller-manager-metrics-service.syn-espejote.svc
+  selector:
+    matchLabels:
+      control-plane: controller-manager

--- a/tests/golden/lib/espejote/espejote/10_kustomize/espejote/rbac.authorization.k8s.io_v1_clusterrole_espejote-manager-role.yaml
+++ b/tests/golden/lib/espejote/espejote/10_kustomize/espejote/rbac.authorization.k8s.io_v1_clusterrole_espejote-manager-role.yaml
@@ -1,0 +1,68 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: espejote-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - espejote.io
+  resources:
+  - admissions
+  - managedresources
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - espejote.io
+  resources:
+  - admissions/finalizers
+  - managedresources/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - espejote.io
+  resources:
+  - admissions/status
+  - managedresources/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - espejote.io
+  resources:
+  - jsonnetlibraries
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/golden/lib/espejote/espejote/10_kustomize/espejote/rbac.authorization.k8s.io_v1_clusterrole_espejote-metrics-auth-role.yaml
+++ b/tests/golden/lib/espejote/espejote/10_kustomize/espejote/rbac.authorization.k8s.io_v1_clusterrole_espejote-metrics-auth-role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: espejote-metrics-auth-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/tests/golden/lib/espejote/espejote/10_kustomize/espejote/rbac.authorization.k8s.io_v1_clusterrole_espejote-metrics-reader.yaml
+++ b/tests/golden/lib/espejote/espejote/10_kustomize/espejote/rbac.authorization.k8s.io_v1_clusterrole_espejote-metrics-reader.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: espejote-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/tests/golden/lib/espejote/espejote/10_kustomize/espejote/rbac.authorization.k8s.io_v1_clusterrolebinding_espejote-manager-rolebinding.yaml
+++ b/tests/golden/lib/espejote/espejote/10_kustomize/espejote/rbac.authorization.k8s.io_v1_clusterrolebinding_espejote-manager-rolebinding.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: espejote
+    app.kubernetes.io/instance: manager-rolebinding
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/part-of: espejote
+  name: espejote-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: espejote-manager-role
+subjects:
+- kind: ServiceAccount
+  name: espejote-controller-manager
+  namespace: syn-espejote

--- a/tests/golden/lib/espejote/espejote/10_kustomize/espejote/rbac.authorization.k8s.io_v1_clusterrolebinding_espejote-metrics-auth-rolebinding.yaml
+++ b/tests/golden/lib/espejote/espejote/10_kustomize/espejote/rbac.authorization.k8s.io_v1_clusterrolebinding_espejote-metrics-auth-rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: espejote-metrics-auth-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: espejote-metrics-auth-role
+subjects:
+- kind: ServiceAccount
+  name: espejote-controller-manager
+  namespace: syn-espejote

--- a/tests/golden/lib/espejote/espejote/10_kustomize/espejote/rbac.authorization.k8s.io_v1_role_espejote-leader-election-role.yaml
+++ b/tests/golden/lib/espejote/espejote/10_kustomize/espejote/rbac.authorization.k8s.io_v1_role_espejote-leader-election-role.yaml
@@ -1,0 +1,44 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: espejote
+    app.kubernetes.io/instance: leader-election-role
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: role
+    app.kubernetes.io/part-of: espejote
+  name: espejote-leader-election-role
+  namespace: syn-espejote
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/tests/golden/lib/espejote/espejote/10_kustomize/espejote/rbac.authorization.k8s.io_v1_rolebinding_espejote-leader-election-rolebinding.yaml
+++ b/tests/golden/lib/espejote/espejote/10_kustomize/espejote/rbac.authorization.k8s.io_v1_rolebinding_espejote-leader-election-rolebinding.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: espejote
+    app.kubernetes.io/instance: leader-election-rolebinding
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: rolebinding
+    app.kubernetes.io/part-of: espejote
+  name: espejote-leader-election-rolebinding
+  namespace: syn-espejote
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: espejote-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: espejote-controller-manager
+  namespace: syn-espejote

--- a/tests/golden/lib/espejote/espejote/10_kustomize/espejote/v1_service_espejote-controller-manager-metrics-service.yaml
+++ b/tests/golden/lib/espejote/espejote/10_kustomize/espejote/v1_service_espejote-controller-manager-metrics-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: espejote
+    control-plane: controller-manager
+  name: espejote-controller-manager-metrics-service
+  namespace: syn-espejote
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/name: espejote
+    control-plane: controller-manager

--- a/tests/golden/lib/espejote/espejote/10_kustomize/espejote/v1_service_espejote-webhook-service.yaml
+++ b/tests/golden/lib/espejote/espejote/10_kustomize/espejote/v1_service_espejote-webhook-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: espejote
+  name: espejote-webhook-service
+  namespace: syn-espejote
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app.kubernetes.io/name: espejote
+    control-plane: controller-manager

--- a/tests/golden/lib/espejote/espejote/10_kustomize/espejote/v1_serviceaccount_espejote-controller-manager.yaml
+++ b/tests/golden/lib/espejote/espejote/10_kustomize/espejote/v1_serviceaccount_espejote-controller-manager.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: espejote
+    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: serviceaccount
+    app.kubernetes.io/part-of: espejote
+  name: espejote-controller-manager
+  namespace: syn-espejote

--- a/tests/golden/lib/espejote/espejote/20_aggregated_cluster_role.yaml
+++ b/tests/golden/lib/espejote/espejote/20_aggregated_cluster_role.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: espejote-crds-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: espejote-crds-cluster-reader
+rules:
+  - apiGroups:
+      - espejote.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/lib/espejote/espejote/30_alerts.yaml
+++ b/tests/golden/lib/espejote/espejote/30_alerts.yaml
@@ -1,0 +1,91 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/name: espejote-alerts
+  name: espejote-alerts
+  namespace: syn-espejote
+spec:
+  groups:
+    - name: espejote
+      rules:
+        - alert: EspejoteAbnormalReconciles
+          annotations:
+            description: |
+              The ManagedResource {{$labels.exported_namespace}}/{{$labels.managedresource}} has been reconciles {{$value}} times more than last week.
+
+              Check which trigger triggers the reconciling `sum by(exported_namespace,managedresource,trigger) (rate(espejote_reconciles_total[10m]))`.
+            runbook_url: https://hub.syn.tools/component-espejote/runbooks/EspejoteAbnormalReconciles.html
+            summary: Abnormal amount of ManagedResource reconciles
+          expr: |2
+                sum by(exported_namespace,managedresource) (rate(espejote_reconciles_total[10m]))
+              /
+                (0.1 + sum by(exported_namespace,managedresource) (rate(espejote_reconciles_total[10m] offset 1w))) > 50
+            and
+              sum by(exported_namespace,managedresource) (increase(espejote_reconciles_total[10m])) > 10
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: espejote
+        - alert: EspejoteAdmissionErrors
+          annotations:
+            description: |
+              The Admission {{$labels.exported_namespace}}/{{$labels.admission}} has errors.
+
+              Admissions should never error and should always return allowed or denied.
+              Check Espejote logs or logs of the requestor.
+            runbook_url: https://hub.syn.tools/component-espejote/runbooks/EspejoteAdmissionErrors.html
+            summary: Admission errors
+          expr: increase(espejote_admission_requests_total{code=~"5.."}[1m]) >= 1
+          for: 1m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: espejote
+        - alert: EspejoteManagedResourceNotReady
+          annotations:
+            description: |
+              The ManagedResource {{$labels.exported_namespace}}/{{$labels.managedresource}} has not been ready for the last 10 minutes.
+
+              Check the status with `k -n "{{$labels.exported_namespace}}" get managedresources.espejote.io` and the events with `kubectl events -n "{{$labels.exported_namespace}}" --for managedresource/{{$labels.managedresource}}` for error information.
+            runbook_url: https://hub.syn.tools/component-espejote/runbooks/EspejoteManagedResourceNotReady.html
+            summary: Managed resource not ready
+          expr: |
+            espejote_managedresource_status_ready == 0
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: espejote
+        - alert: EspejoteManagedResourceReadinessChanges
+          annotations:
+            description: |
+              The ManagedResource {{$labels.exported_namespace}}/{{$labels.managedresource}} has changed status {{$value}} times within 10 minutes.
+
+              Check events with `kubectl events -n "{{$labels.exported_namespace}}" --for managedresource/{{$labels.managedresource}}` for error information.
+            runbook_url: https://hub.syn.tools/component-espejote/runbooks/EspejoteManagedResourceReadinessChanges.html
+            summary: Too many managed resource readiness changes.
+          expr: |
+            changes(espejote_managedresource_status_ready[10m]) > 10
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: espejote
+        - alert: EspejoteOutOfMemoryEvents
+          annotations:
+            description: |
+              An espejote container had {{$value}} OOM events within 10 minutes.
+
+              Increase memory available to Espejote or reduce resource usage of the ManagedResources or Admissions.
+              Check memory usage of managed resources with `topk(10,sum by(exported_namespace,managedresource,name) (espejote_cache_size_bytes))`.
+            runbook_url: https://hub.syn.tools/component-espejote/runbooks/EspejoteOutOfMemoryEvents.html
+            summary: Espejote is out of memory
+          expr: |
+            increase(container_oom_events_total{namespace="syn-espejote"}[10m]) > 2
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: espejote

--- a/tests/golden/lib/espejote/tests/image_config.yaml
+++ b/tests/golden/lib/espejote/tests/image_config.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: config-openshift-io-images-cluster-manager
+  namespace: openshift-config
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openshift-config:config-openshift-io-images-cluster-manager
+rules:
+  - apiGroups:
+      - config.openshift.io
+    resourceNames:
+      - cluster
+    resources:
+      - images
+    verbs:
+      - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openshift-config:config-openshift-io-images-cluster-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-config:config-openshift-io-images-cluster-manager
+subjects:
+  - kind: ServiceAccount
+    name: config-openshift-io-images-cluster-manager
+    namespace: openshift-config
+---
+apiVersion: espejote.io/v1alpha1
+kind: ManagedResource
+metadata:
+  labels:
+    app.kubernetes.io/name: config-openshift-io-images-cluster-manager
+  name: config-openshift-io-images-cluster-manager
+  namespace: openshift-config
+spec:
+  applyOptions:
+    force: true
+  serviceAccountRef:
+    name: config-openshift-io-images-cluster-manager
+  template: |-
+    {
+        "apiVersion": "config.openshift.io/v1",
+        "kind": "Image",
+        "metadata": {
+            "name": "cluster"
+        },
+        "spec": {
+            "allowedRegistriesForImport": [
+                {
+                    "domainName": "ghcr.io"
+                }
+            ]
+        }
+    }
+  triggers:
+    - name: target
+      watchResource:
+        apiVersion: config.openshift.io/v1
+        kind: Image
+        name: cluster

--- a/tests/golden/lib/espejote/tests/image_config_override.yaml
+++ b/tests/golden/lib/espejote/tests/image_config_override.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: image-config-openshift-io-mgr
+  namespace: openshift-config
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openshift-config:image-config-openshift-io-mgr
+rules:
+  - apiGroups:
+      - config.openshift.io
+    resourceNames:
+      - cluster
+    resources:
+      - images
+    verbs:
+      - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openshift-config:image-config-openshift-io-mgr
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-config:image-config-openshift-io-mgr
+subjects:
+  - kind: ServiceAccount
+    name: image-config-openshift-io-mgr
+    namespace: openshift-config
+---
+apiVersion: espejote.io/v1alpha1
+kind: ManagedResource
+metadata:
+  labels:
+    app.kubernetes.io/name: image-config-openshift-io-mgr
+  name: image-config-openshift-io-mgr
+  namespace: openshift-config
+spec:
+  applyOptions:
+    force: true
+  serviceAccountRef:
+    name: image-config-openshift-io-mgr
+  template: |-
+    {
+        "apiVersion": "config.openshift.io/v1",
+        "kind": "Image",
+        "metadata": {
+            "name": "cluster"
+        },
+        "spec": {
+            "allowedRegistriesForImport": [
+                {
+                    "domainName": "ghcr.io"
+                }
+            ]
+        }
+    }
+  triggers:
+    - name: target
+      watchResource:
+        apiVersion: config.openshift.io/v1
+        kind: Image
+        name: cluster

--- a/tests/lib.yml
+++ b/tests/lib.yml
@@ -1,0 +1,7 @@
+parameters:
+  kapitan:
+    compile:
+      - input_type: jsonnet
+        input_paths:
+          - ${_base_directory}/tests/test-partial-cluster-scoped-resource.jsonnet
+        output_path: tests/

--- a/tests/test-partial-cluster-scoped-resource.jsonnet
+++ b/tests/test-partial-cluster-scoped-resource.jsonnet
@@ -1,0 +1,36 @@
+local esp = import 'lib/espejote.libsonnet';
+
+{
+  image_config: esp.clusterScopedObject(
+    'openshift-config',
+    {
+      apiVersion: 'config.openshift.io/v1',
+      kind: 'Image',
+      metadata: {
+        name: 'cluster',
+      },
+      spec: {
+        allowedRegistriesForImport: [ {
+          domainName: 'ghcr.io',
+        } ],
+      },
+    }
+  ),
+  image_config_override: esp.clusterScopedObject(
+    'openshift-config',
+    {
+      apiVersion: 'config.openshift.io/v1',
+      kind: 'Image',
+      metadata: {
+        name: 'cluster',
+      },
+      spec: {
+        allowedRegistriesForImport: [ {
+          domainName: 'ghcr.io',
+        } ],
+      },
+    },
+    resource='images',
+    mgr_name='image-config-openshift-io-mgr'
+  ),
+}


### PR DESCRIPTION
This helper generates a service account, cluster role, cluster role binding and managed resoruce which apply a partial manifest for a cluster-scoped resource. This is particularly helpful on OpenShift where there are many cluster-scoped singleton resources which are used to configure OpenShift.


## TODO

 - [x] Add test for library function

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
