### PR TITLE
Remove default CPU limit

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -20,7 +20,7 @@ parameters:
           cpu: 10m
           memory: 32Mi
         limits:
-          cpu: 100m
+          cpu: null
           memory: 128Mi
 
     jsonnetLibraries: {}

--- a/tests/golden/defaults/espejote/espejote/10_kustomize/espejote/apps_v1_deployment_espejote-controller-manager.yaml
+++ b/tests/golden/defaults/espejote/espejote/10_kustomize/espejote/apps_v1_deployment_espejote-controller-manager.yaml
@@ -57,7 +57,6 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 100m
             memory: 128Mi
           requests:
             cpu: 10m

--- a/tests/golden/lib/espejote/espejote/10_kustomize/espejote/apps_v1_deployment_espejote-controller-manager.yaml
+++ b/tests/golden/lib/espejote/espejote/10_kustomize/espejote/apps_v1_deployment_espejote-controller-manager.yaml
@@ -57,7 +57,6 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 100m
             memory: 128Mi
           requests:
             cpu: 10m


### PR DESCRIPTION
Jsonnet rendering can be peaky, this will speedup rendering of large templates.

[For the Love of God, Stop Using CPU Limits on Kubernetes](https://home.robusta.dev/blog/stop-using-cpu-limits)

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
