### PR TITLE
Fix `app.kubernetes.io/name` label containing colons for supplemental roles

### DIFF
--- a/tests/golden/resources/espejote/espejote/43_supplemental_role_my-namespace_auto-roles-1.yaml
+++ b/tests/golden/resources/espejote/espejote/43_supplemental_role_my-namespace_auto-roles-1.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    app.kubernetes.io/name: espejote:supplemental:my-namespace:auto-roles-1:espejote-update-configmaps
+    app.kubernetes.io/name: espejote-supplemental-my-namespace-auto-roles-1-espejote-update-configmaps
   name: espejote:supplemental:my-namespace:auto-roles-1:espejote-update-configmaps
   namespace: my-namespace
 rules:
@@ -19,7 +19,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: espejote:supplemental:espejote-update-configmaps:espejote-auto-roles-1
+    app.kubernetes.io/name: espejote-supplemental-espejote-update-configmaps-espejote-auto-roles-1
   name: espejote:supplemental:espejote-update-configmaps:espejote-auto-roles-1
   namespace: my-namespace
 roleRef:

--- a/tests/golden/resources/espejote/espejote/43_supplemental_role_my-namespace_copy-configmap.yaml
+++ b/tests/golden/resources/espejote/espejote/43_supplemental_role_my-namespace_copy-configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    app.kubernetes.io/name: espejote:supplemental:my-namespace:copy-configmap:configmaps
+    app.kubernetes.io/name: espejote-supplemental-my-namespace-copy-configmap-configmaps
   name: espejote:supplemental:my-namespace:copy-configmap:configmaps
   namespace: a
 rules:
@@ -17,7 +17,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    app.kubernetes.io/name: espejote:supplemental:my-namespace:copy-configmap:configmaps
+    app.kubernetes.io/name: espejote-supplemental-my-namespace-copy-configmap-configmaps
   name: espejote:supplemental:my-namespace:copy-configmap:configmaps
   namespace: b
 rules:
@@ -32,7 +32,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    app.kubernetes.io/name: espejote:supplemental:my-namespace:copy-configmap:configmaps
+    app.kubernetes.io/name: espejote-supplemental-my-namespace-copy-configmap-configmaps
   name: espejote:supplemental:my-namespace:copy-configmap:configmaps
   namespace: my-namespace
 rules:
@@ -47,7 +47,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: espejote:supplemental:configmaps:my-namespace:espejote-copy-configmap
+    app.kubernetes.io/name: espejote-supplemental-configmaps-my-namespace-espejote-copy-configmap
   name: espejote:supplemental:configmaps:my-namespace:espejote-copy-configmap
   namespace: a
 roleRef:
@@ -63,7 +63,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: espejote:supplemental:configmaps:my-namespace:espejote-copy-configmap
+    app.kubernetes.io/name: espejote-supplemental-configmaps-my-namespace-espejote-copy-configmap
   name: espejote:supplemental:configmaps:my-namespace:espejote-copy-configmap
   namespace: b
 roleRef:
@@ -79,7 +79,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: espejote:supplemental:configmaps:espejote-copy-configmap
+    app.kubernetes.io/name: espejote-supplemental-configmaps-espejote-copy-configmap
   name: espejote:supplemental:configmaps:espejote-copy-configmap
   namespace: my-namespace
 roleRef:

--- a/tests/golden/resources/espejote/espejote/43_supplemental_role_my-namespace_copy-secret.yaml
+++ b/tests/golden/resources/espejote/espejote/43_supplemental_role_my-namespace_copy-secret.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: espejote:supplemental:admin:espejote-copy-secret
+    app.kubernetes.io/name: espejote-supplemental-admin-espejote-copy-secret
   name: espejote:supplemental:admin:espejote-copy-secret
   namespace: my-namespace
 roleRef:
@@ -18,7 +18,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: espejote:supplemental:argocd-manager:espejote-copy-secret
+    app.kubernetes.io/name: espejote-supplemental-argocd-manager-espejote-copy-secret
   name: espejote:supplemental:argocd-manager:espejote-copy-secret
   namespace: my-namespace
 roleRef:

--- a/tests/golden/resources/espejote/espejote/44_supplemental_cluster_role_my-namespace_copy-configmap.yaml
+++ b/tests/golden/resources/espejote/espejote/44_supplemental_cluster_role_my-namespace_copy-configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: espejote:supplemental:my-namespace:copy-configmap:namespace
+    app.kubernetes.io/name: espejote-supplemental-my-namespace-copy-configmap-namespace
   name: espejote:supplemental:my-namespace:copy-configmap:namespace
 rules:
   - apiGroups:
@@ -16,7 +16,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: espejote:supplemental:namespace:my-namespace:espejote-copy-configmap
+    app.kubernetes.io/name: espejote-supplemental-namespace-my-namespace-espejote-copy-configmap
   name: espejote:supplemental:namespace:my-namespace:espejote-copy-configmap
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
