### PR TITLE
Fix broken `roleRef` for supplemental cluster roles

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -175,6 +175,9 @@ local clusterRoleBinding(roleNamePrefix) =
   function(roleName, saNs, saName)
     roleBinding(roleNamePrefix)(null, roleName, saNs, saName) + {
       kind: 'ClusterRoleBinding',
+      roleRef+: {
+        kind: 'ClusterRole',
+      },
     };
 
 local roleBindingsForManagedResourceAndRoles(roleNamePrefix) =

--- a/tests/golden/resources/espejote/espejote/44_supplemental_cluster_role_my-namespace_copy-configmap.yaml
+++ b/tests/golden/resources/espejote/espejote/44_supplemental_cluster_role_my-namespace_copy-configmap.yaml
@@ -20,7 +20,7 @@ metadata:
   name: espejote:supplemental:namespace:my-namespace:espejote-copy-configmap
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: espejote:supplemental:my-namespace:copy-configmap:namespace
 subjects:
   - kind: ServiceAccount


### PR DESCRIPTION
## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
