### PR TITLE
Shorten generated RBAC names and fail if names are too long

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -131,10 +131,12 @@ local serviceAccount(mrName) = addKubernetesNameLabel({
 local role(prefix, defaultNamespace) =
   function(path) addKubernetesNameLabel({
     local nsName = namespacedName(path, namespace=defaultNamespace),
+    local name = prefix + nsName.name,
+    assert std.length(name) <= 63 : "Resource name '%s' too long!" % name,
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'Role',
     metadata: {
-      name: prefix + nsName.name,
+      name: name,
       namespace: nsName.namespace,
     },
   });
@@ -150,7 +152,7 @@ local clusterRole(prefix) =
 
 local roleBinding(roleNamePrefix) =
   function(roleNs, roleName, saNs, saName) addKubernetesNameLabel({
-    local bindingName = std.join(':', std.prune([ 'espejote', 'supplemental', roleName, if saNs != roleNs then saNs, saName ])),
+    local bindingName = std.join(':', std.prune([ 'esp', 'x', roleName, if saNs != roleNs then saNs, saName ])),
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'RoleBinding',
     metadata: {
@@ -204,7 +206,7 @@ local supplementalRoles = std.prune({
   ['43_supplemental_role_%(namespace)s_%(name)s' % namespacedName(path)]:
     local roles = std.get(params.managedResources[path], '_roles', {});
     local mrNsName = namespacedName(path);
-    local roleNamePrefix = std.join(':', [ 'espejote', 'supplemental', mrNsName.namespace, mrNsName.name, '' ]);
+    local roleNamePrefix = std.join(':', [ 'esp', 'x', mrNsName.namespace, mrNsName.name, '' ]);
     com.generateResources(roles, role(roleNamePrefix, mrNsName.namespace)) +
     roleBindingsForManagedResourceAndRoles(roleNamePrefix)(path, std.objectFields(roles)) +
     roleBindingsForManagedResourceAndRoles(roleNamePrefix)(path, std.get(params.managedResources[path], '_roleBindings', []))
@@ -215,7 +217,7 @@ local supplementalClusterRoles = std.prune({
   [if std.length(std.get(params.managedResources[path], '_clusterRoles', {})) > 0 then '44_supplemental_cluster_role_%(namespace)s_%(name)s' % namespacedName(path)]:
     local roles = std.get(params.managedResources[path], '_clusterRoles', {});
     local mrNsName = namespacedName(path);
-    local roleNamePrefix = std.join(':', [ 'espejote', 'supplemental', mrNsName.namespace, mrNsName.name, '' ]);
+    local roleNamePrefix = std.join(':', [ 'esp', 'x', mrNsName.namespace, mrNsName.name, '' ]);
     com.generateResources(roles, clusterRole(roleNamePrefix)) +
     clusterRoleBindingsForManagedResourceAndRoles(roleNamePrefix)(path, std.objectFields(roles)) +
     clusterRoleBindingsForManagedResourceAndRoles(roleNamePrefix)(path, std.get(params.managedResources[path], '_clusterRoleBindings', []))

--- a/lib/espejote.libsonnet
+++ b/lib/espejote.libsonnet
@@ -126,12 +126,15 @@ local generateRolesForManagedResource(manifest) =
     kind: if clusterScoped(resource) then 'ClusterRole' else 'Role',
     metadata: {
       [if !clusterScoped(resource) then 'namespace']: resourceNs,
-      name: std.join(':', std.prune([
-        'espejote',
-        'managedresource',
-        if clusterScoped(resource) || manifestMeta.namespace != resourceNs then manifestMeta.namespace,
-        manifestMeta.name,
-      ] + suffixes)),
+      name:
+        local name = std.join(':', std.prune([
+          'esp',
+          'mr',
+          if clusterScoped(resource) || manifestMeta.namespace != resourceNs then manifestMeta.namespace,
+          manifestMeta.name,
+        ] + suffixes));
+        assert std.length(name) <= 63 : "Resource name '%s' too long!" % name;
+        name,
     },
     rules: [
       {
@@ -145,11 +148,11 @@ local generateRolesForManagedResource(manifest) =
   };
 
   [
-    roleFromResource([ 'triggers', item.name ], item.watchResource)
+    roleFromResource([ 'trg', item.name ], item.watchResource)
     for item in std.get(manifestSpec, 'triggers', [])
     if std.get(std.get(item, 'watchResource', {}), 'kind', '') != ''
   ] + [
-    roleFromResource([ 'context', item.name ], item.resource)
+    roleFromResource([ 'ctx', item.name ], item.resource)
     for item in std.get(manifestSpec, 'context', [])
     if std.get(std.get(item, 'resource', {}), 'kind', '') != ''
   ];

--- a/tests/golden/resources/espejote/espejote/43_supplemental_role_my-namespace_auto-roles-1.yaml
+++ b/tests/golden/resources/espejote/espejote/43_supplemental_role_my-namespace_auto-roles-1.yaml
@@ -2,8 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    app.kubernetes.io/name: espejote-supplemental-my-namespace-auto-roles-1-espejote-update-configmaps
-  name: espejote:supplemental:my-namespace:auto-roles-1:espejote-update-configmaps
+    app.kubernetes.io/name: esp-x-my-namespace-auto-roles-1-espejote-update-configmaps
+  name: esp:x:my-namespace:auto-roles-1:espejote-update-configmaps
   namespace: my-namespace
 rules:
   - apiGroups:
@@ -19,13 +19,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: espejote-supplemental-espejote-update-configmaps-espejote-auto-roles-1
-  name: espejote:supplemental:espejote-update-configmaps:espejote-auto-roles-1
+    app.kubernetes.io/name: esp-x-espejote-update-configmaps-espejote-auto-roles-1
+  name: esp:x:espejote-update-configmaps:espejote-auto-roles-1
   namespace: my-namespace
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: espejote:supplemental:my-namespace:auto-roles-1:espejote-update-configmaps
+  name: esp:x:my-namespace:auto-roles-1:espejote-update-configmaps
 subjects:
   - kind: ServiceAccount
     name: espejote-auto-roles-1

--- a/tests/golden/resources/espejote/espejote/43_supplemental_role_my-namespace_copy-configmap.yaml
+++ b/tests/golden/resources/espejote/espejote/43_supplemental_role_my-namespace_copy-configmap.yaml
@@ -2,8 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    app.kubernetes.io/name: espejote-supplemental-my-namespace-copy-configmap-configmaps
-  name: espejote:supplemental:my-namespace:copy-configmap:configmaps
+    app.kubernetes.io/name: esp-x-my-namespace-copy-configmap-configmaps
+  name: esp:x:my-namespace:copy-configmap:configmaps
   namespace: a
 rules:
   - apiGroups:
@@ -17,8 +17,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    app.kubernetes.io/name: espejote-supplemental-my-namespace-copy-configmap-configmaps
-  name: espejote:supplemental:my-namespace:copy-configmap:configmaps
+    app.kubernetes.io/name: esp-x-my-namespace-copy-configmap-configmaps
+  name: esp:x:my-namespace:copy-configmap:configmaps
   namespace: b
 rules:
   - apiGroups:
@@ -32,8 +32,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    app.kubernetes.io/name: espejote-supplemental-my-namespace-copy-configmap-configmaps
-  name: espejote:supplemental:my-namespace:copy-configmap:configmaps
+    app.kubernetes.io/name: esp-x-my-namespace-copy-configmap-configmaps
+  name: esp:x:my-namespace:copy-configmap:configmaps
   namespace: my-namespace
 rules:
   - apiGroups:
@@ -47,13 +47,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: espejote-supplemental-configmaps-my-namespace-espejote-copy-configmap
-  name: espejote:supplemental:configmaps:my-namespace:espejote-copy-configmap
+    app.kubernetes.io/name: esp-x-configmaps-my-namespace-espejote-copy-configmap
+  name: esp:x:configmaps:my-namespace:espejote-copy-configmap
   namespace: a
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: espejote:supplemental:my-namespace:copy-configmap:configmaps
+  name: esp:x:my-namespace:copy-configmap:configmaps
 subjects:
   - kind: ServiceAccount
     name: espejote-copy-configmap
@@ -63,13 +63,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: espejote-supplemental-configmaps-my-namespace-espejote-copy-configmap
-  name: espejote:supplemental:configmaps:my-namespace:espejote-copy-configmap
+    app.kubernetes.io/name: esp-x-configmaps-my-namespace-espejote-copy-configmap
+  name: esp:x:configmaps:my-namespace:espejote-copy-configmap
   namespace: b
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: espejote:supplemental:my-namespace:copy-configmap:configmaps
+  name: esp:x:my-namespace:copy-configmap:configmaps
 subjects:
   - kind: ServiceAccount
     name: espejote-copy-configmap
@@ -79,13 +79,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: espejote-supplemental-configmaps-espejote-copy-configmap
-  name: espejote:supplemental:configmaps:espejote-copy-configmap
+    app.kubernetes.io/name: esp-x-configmaps-espejote-copy-configmap
+  name: esp:x:configmaps:espejote-copy-configmap
   namespace: my-namespace
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: espejote:supplemental:my-namespace:copy-configmap:configmaps
+  name: esp:x:my-namespace:copy-configmap:configmaps
 subjects:
   - kind: ServiceAccount
     name: espejote-copy-configmap

--- a/tests/golden/resources/espejote/espejote/43_supplemental_role_my-namespace_copy-secret.yaml
+++ b/tests/golden/resources/espejote/espejote/43_supplemental_role_my-namespace_copy-secret.yaml
@@ -2,13 +2,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: espejote-supplemental-admin-copy-configmap
-  name: espejote:supplemental:admin:copy-configmap
+    app.kubernetes.io/name: esp-x-admin-copy-configmap
+  name: esp:x:admin:copy-configmap
   namespace: my-namespace
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: espejote:supplemental:my-namespace:copy-secret:admin
+  name: esp:x:my-namespace:copy-secret:admin
 subjects:
   - kind: ServiceAccount
     name: copy-configmap
@@ -18,13 +18,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: espejote-supplemental-argocd-manager-copy-configmap
-  name: espejote:supplemental:argocd-manager:copy-configmap
+    app.kubernetes.io/name: esp-x-argocd-manager-copy-configmap
+  name: esp:x:argocd-manager:copy-configmap
   namespace: my-namespace
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: espejote:supplemental:my-namespace:copy-secret:argocd-manager
+  name: esp:x:my-namespace:copy-secret:argocd-manager
 subjects:
   - kind: ServiceAccount
     name: copy-configmap

--- a/tests/golden/resources/espejote/espejote/44_supplemental_cluster_role_my-namespace_copy-configmap.yaml
+++ b/tests/golden/resources/espejote/espejote/44_supplemental_cluster_role_my-namespace_copy-configmap.yaml
@@ -2,8 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: espejote-supplemental-my-namespace-copy-configmap-namespace
-  name: espejote:supplemental:my-namespace:copy-configmap:namespace
+    app.kubernetes.io/name: esp-x-my-namespace-copy-configmap-namespace
+  name: esp:x:my-namespace:copy-configmap:namespace
 rules:
   - apiGroups:
       - ''
@@ -16,12 +16,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: espejote-supplemental-namespace-my-namespace-espejote-copy-configmap
-  name: espejote:supplemental:namespace:my-namespace:espejote-copy-configmap
+    app.kubernetes.io/name: esp-x-namespace-my-namespace-espejote-copy-configmap
+  name: esp:x:namespace:my-namespace:espejote-copy-configmap
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: espejote:supplemental:my-namespace:copy-configmap:namespace
+  name: esp:x:my-namespace:copy-configmap:namespace
 subjects:
   - kind: ServiceAccount
     name: espejote-copy-configmap

--- a/tests/golden/resources/espejote/espejote/60_mr_my-namespace_auto-roles-1.yaml
+++ b/tests/golden/resources/espejote/espejote/60_mr_my-namespace_auto-roles-1.yaml
@@ -51,7 +51,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: espejote:managedresource:my-namespace:auto-roles-1:triggers:namespace
+  name: esp:mr:my-namespace:auto-roles-1:trg:namespace
 rules:
   - apiGroups:
       - ''
@@ -65,7 +65,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: espejote:managedresource:my-namespace:auto-roles-1:triggers:configmap
+  name: esp:mr:my-namespace:auto-roles-1:trg:configmap
 rules:
   - apiGroups:
       - ''
@@ -79,7 +79,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: espejote:managedresource:my-namespace:auto-roles-1:triggers:override-namespaced-1
+  name: esp:mr:my-namespace:auto-roles-1:trg:override-namespaced-1
 rules:
   - apiGroups:
       - ''
@@ -93,7 +93,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: espejote:managedresource:auto-roles-1:triggers:override-namespaced-2
+  name: esp:mr:auto-roles-1:trg:override-namespaced-2
   namespace: my-namespace
 rules:
   - apiGroups:
@@ -108,7 +108,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: espejote:managedresource:auto-roles-1:triggers:weird-resource
+  name: esp:mr:auto-roles-1:trg:weird-resource
   namespace: my-namespace
 rules:
   - apiGroups:
@@ -123,11 +123,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: espejote:managedresource:my-namespace:auto-roles-1:triggers:namespace
+  name: esp:mr:my-namespace:auto-roles-1:trg:namespace
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: espejote:managedresource:my-namespace:auto-roles-1:triggers:namespace
+  name: esp:mr:my-namespace:auto-roles-1:trg:namespace
 subjects:
   - kind: ServiceAccount
     name: espejote-auto-roles-1
@@ -136,11 +136,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: espejote:managedresource:my-namespace:auto-roles-1:triggers:configmap
+  name: esp:mr:my-namespace:auto-roles-1:trg:configmap
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: espejote:managedresource:my-namespace:auto-roles-1:triggers:configmap
+  name: esp:mr:my-namespace:auto-roles-1:trg:configmap
 subjects:
   - kind: ServiceAccount
     name: espejote-auto-roles-1
@@ -149,11 +149,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: espejote:managedresource:my-namespace:auto-roles-1:triggers:override-namespaced-1
+  name: esp:mr:my-namespace:auto-roles-1:trg:override-namespaced-1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: espejote:managedresource:my-namespace:auto-roles-1:triggers:override-namespaced-1
+  name: esp:mr:my-namespace:auto-roles-1:trg:override-namespaced-1
 subjects:
   - kind: ServiceAccount
     name: espejote-auto-roles-1
@@ -162,12 +162,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: espejote:managedresource:auto-roles-1:triggers:override-namespaced-2
+  name: esp:mr:auto-roles-1:trg:override-namespaced-2
   namespace: my-namespace
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: espejote:managedresource:auto-roles-1:triggers:override-namespaced-2
+  name: esp:mr:auto-roles-1:trg:override-namespaced-2
 subjects:
   - kind: ServiceAccount
     name: espejote-auto-roles-1
@@ -176,12 +176,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: espejote:managedresource:auto-roles-1:triggers:weird-resource
+  name: esp:mr:auto-roles-1:trg:weird-resource
   namespace: my-namespace
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: espejote:managedresource:auto-roles-1:triggers:weird-resource
+  name: esp:mr:auto-roles-1:trg:weird-resource
 subjects:
   - kind: ServiceAccount
     name: espejote-auto-roles-1

--- a/tests/golden/resources/espejote/espejote/60_mr_my-namespace_auto-roles-2.yaml
+++ b/tests/golden/resources/espejote/espejote/60_mr_my-namespace_auto-roles-2.yaml
@@ -50,7 +50,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: espejote:managedresource:auto-roles-2:triggers:configmap
+  name: esp:mr:auto-roles-2:trg:configmap
   namespace: my-namespace
 rules:
   - apiGroups:
@@ -65,7 +65,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: espejote:managedresource:auto-roles-2:triggers:secret
+  name: esp:mr:auto-roles-2:trg:secret
   namespace: my-namespace
 rules:
   - apiGroups:
@@ -80,7 +80,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: espejote:managedresource:my-namespace:auto-roles-2:triggers:pod
+  name: esp:mr:my-namespace:auto-roles-2:trg:pod
   namespace: other-namespace
 rules:
   - apiGroups:
@@ -95,7 +95,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: espejote:managedresource:my-namespace:auto-roles-2:context:namespaces
+  name: esp:mr:my-namespace:auto-roles-2:ctx:namespaces
 rules:
   - apiGroups:
       - ''
@@ -109,7 +109,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: espejote:managedresource:auto-roles-2:context:configmap
+  name: esp:mr:auto-roles-2:ctx:configmap
   namespace: my-namespace
 rules:
   - apiGroups:
@@ -124,12 +124,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: espejote:managedresource:auto-roles-2:triggers:configmap
+  name: esp:mr:auto-roles-2:trg:configmap
   namespace: my-namespace
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: espejote:managedresource:auto-roles-2:triggers:configmap
+  name: esp:mr:auto-roles-2:trg:configmap
 subjects:
   - kind: ServiceAccount
     name: espejote-auto-roles-2
@@ -138,12 +138,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: espejote:managedresource:auto-roles-2:triggers:secret
+  name: esp:mr:auto-roles-2:trg:secret
   namespace: my-namespace
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: espejote:managedresource:auto-roles-2:triggers:secret
+  name: esp:mr:auto-roles-2:trg:secret
 subjects:
   - kind: ServiceAccount
     name: espejote-auto-roles-2
@@ -152,12 +152,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: espejote:managedresource:my-namespace:auto-roles-2:triggers:pod
+  name: esp:mr:my-namespace:auto-roles-2:trg:pod
   namespace: other-namespace
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: espejote:managedresource:my-namespace:auto-roles-2:triggers:pod
+  name: esp:mr:my-namespace:auto-roles-2:trg:pod
 subjects:
   - kind: ServiceAccount
     name: espejote-auto-roles-2
@@ -166,11 +166,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: espejote:managedresource:my-namespace:auto-roles-2:context:namespaces
+  name: esp:mr:my-namespace:auto-roles-2:ctx:namespaces
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: espejote:managedresource:my-namespace:auto-roles-2:context:namespaces
+  name: esp:mr:my-namespace:auto-roles-2:ctx:namespaces
 subjects:
   - kind: ServiceAccount
     name: espejote-auto-roles-2
@@ -179,12 +179,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: espejote:managedresource:auto-roles-2:context:configmap
+  name: esp:mr:auto-roles-2:ctx:configmap
   namespace: my-namespace
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: espejote:managedresource:auto-roles-2:context:configmap
+  name: esp:mr:auto-roles-2:ctx:configmap
 subjects:
   - kind: ServiceAccount
     name: espejote-auto-roles-2


### PR DESCRIPTION
The PR adds assertions for generated role/clusterrole names that fail if a generated name is longer than 63 characters. Note that we don't need to do this for rolebindings/clusterrolebindings.

Additionally, the PR reduces excessive prefix/segment length (`esp:x:` instead of `espejote:supplemental:`, `esp:mr:` instead of `espejote:managedresource:`, `ctx` instead of `context` and `trg` instead of `trigger`) for generated RBAC names to leave a bit more room for the segments derived from the user-selected namespace and  managedresource
name.


## TODO

- [x] Split into multiple commits -> #46 


## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
