### PR TITLE
Set ArgoCD SkipDryRunOnMissingResource sync option for all CRs 

### DIFF
--- a/lib/espejote.libsonnet
+++ b/lib/espejote.libsonnet
@@ -23,6 +23,9 @@ local jsonnetLibrary(name, namespace) = {
     labels: {
       'app.kubernetes.io/name': name,
     },
+    annotations: {
+      'argocd.argoproj.io/sync-options': 'SkipDryRunOnMissingResource=true',
+    },
     name: name,
     namespace: namespace,
   },
@@ -42,6 +45,9 @@ local admission(name, namespace) = {
     labels: {
       'app.kubernetes.io/name': name,
     },
+    annotations: {
+      'argocd.argoproj.io/sync-options': 'SkipDryRunOnMissingResource=true',
+    },
     name: name,
     namespace: namespace,
   },
@@ -60,6 +66,9 @@ local clusterAdmission(name) = {
     labels: {
       'app.kubernetes.io/name': name,
     },
+    annotations: {
+      'argocd.argoproj.io/sync-options': 'SkipDryRunOnMissingResource=true',
+    },
     name: name,
   },
 };
@@ -77,6 +86,9 @@ local managedResource(name, namespace) = {
   metadata: {
     labels: {
       'app.kubernetes.io/name': name,
+    },
+    annotations: {
+      'argocd.argoproj.io/sync-options': 'SkipDryRunOnMissingResource=true',
     },
     name: name,
     namespace: namespace,

--- a/tests/golden/lib/espejote/tests/image_config.yaml
+++ b/tests/golden/lib/espejote/tests/image_config.yaml
@@ -34,6 +34,8 @@ subjects:
 apiVersion: espejote.io/v1alpha1
 kind: ManagedResource
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/name: config-openshift-io-images-cluster-manager
   name: config-openshift-io-images-cluster-manager

--- a/tests/golden/lib/espejote/tests/image_config_override.yaml
+++ b/tests/golden/lib/espejote/tests/image_config_override.yaml
@@ -34,6 +34,8 @@ subjects:
 apiVersion: espejote.io/v1alpha1
 kind: ManagedResource
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/name: image-config-openshift-io-mgr
   name: image-config-openshift-io-mgr

--- a/tests/golden/resources/espejote/espejote/50_jl_a_my-lib.yaml
+++ b/tests/golden/resources/espejote/espejote/50_jl_a_my-lib.yaml
@@ -1,6 +1,8 @@
 apiVersion: espejote.io/v1alpha1
 kind: JsonnetLibrary
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/name: my-lib
   name: my-lib

--- a/tests/golden/resources/espejote/espejote/50_jl_syn-espejote_my-lib.yaml
+++ b/tests/golden/resources/espejote/espejote/50_jl_syn-espejote_my-lib.yaml
@@ -1,6 +1,8 @@
 apiVersion: espejote.io/v1alpha1
 kind: JsonnetLibrary
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/name: my-lib
   name: my-lib

--- a/tests/golden/resources/espejote/espejote/60_mr_my-namespace_auto-roles-1.yaml
+++ b/tests/golden/resources/espejote/espejote/60_mr_my-namespace_auto-roles-1.yaml
@@ -10,6 +10,8 @@ metadata:
 apiVersion: espejote.io/v1alpha1
 kind: ManagedResource
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/name: auto-roles-1
   name: auto-roles-1

--- a/tests/golden/resources/espejote/espejote/60_mr_my-namespace_auto-roles-2.yaml
+++ b/tests/golden/resources/espejote/espejote/60_mr_my-namespace_auto-roles-2.yaml
@@ -10,6 +10,8 @@ metadata:
 apiVersion: espejote.io/v1alpha1
 kind: ManagedResource
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/name: auto-roles-2
   name: auto-roles-2

--- a/tests/golden/resources/espejote/espejote/60_mr_my-namespace_copy-configmap.yaml
+++ b/tests/golden/resources/espejote/espejote/60_mr_my-namespace_copy-configmap.yaml
@@ -10,6 +10,8 @@ metadata:
 apiVersion: espejote.io/v1alpha1
 kind: ManagedResource
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/name: copy-configmap
   name: copy-configmap

--- a/tests/golden/resources/espejote/espejote/60_mr_my-namespace_copy-secret.yaml
+++ b/tests/golden/resources/espejote/espejote/60_mr_my-namespace_copy-secret.yaml
@@ -10,6 +10,8 @@ metadata:
 apiVersion: espejote.io/v1alpha1
 kind: ManagedResource
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/name: copy-secret
   name: copy-secret

--- a/tests/golden/resources/espejote/espejote/60_mr_syn-espejote_with-sa-in-spec.yaml
+++ b/tests/golden/resources/espejote/espejote/60_mr_syn-espejote_with-sa-in-spec.yaml
@@ -10,6 +10,8 @@ metadata:
 apiVersion: espejote.io/v1alpha1
 kind: ManagedResource
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/name: with-sa-in-spec
   name: with-sa-in-spec

--- a/tests/golden/resources/espejote/espejote/60_mr_syn-espejote_with-sa.yaml
+++ b/tests/golden/resources/espejote/espejote/60_mr_syn-espejote_with-sa.yaml
@@ -10,6 +10,8 @@ metadata:
 apiVersion: espejote.io/v1alpha1
 kind: ManagedResource
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/name: with-sa
   name: with-sa

--- a/tests/golden/resources/espejote/espejote/60_mr_syn-espejote_without-sa.yaml
+++ b/tests/golden/resources/espejote/espejote/60_mr_syn-espejote_without-sa.yaml
@@ -10,6 +10,8 @@ metadata:
 apiVersion: espejote.io/v1alpha1
 kind: ManagedResource
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/name: without-sa
   name: without-sa

--- a/tests/golden/resources/espejote/espejote/70_adm_my-namespace_test-admission.yaml
+++ b/tests/golden/resources/espejote/espejote/70_adm_my-namespace_test-admission.yaml
@@ -1,6 +1,8 @@
 apiVersion: espejote.io/v1alpha1
 kind: Admission
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/name: test-admission
   name: test-admission

--- a/tests/golden/resources/espejote/espejote/70_adm_syn-espejote_test-admission.yaml
+++ b/tests/golden/resources/espejote/espejote/70_adm_syn-espejote_test-admission.yaml
@@ -1,6 +1,8 @@
 apiVersion: espejote.io/v1alpha1
 kind: Admission
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/name: test-admission
   name: test-admission

--- a/tests/golden/resources/espejote/espejote/70_cadm_test-cluster-admission.yaml
+++ b/tests/golden/resources/espejote/espejote/70_cadm_test-cluster-admission.yaml
@@ -1,6 +1,8 @@
 apiVersion: espejote.io/v1alpha1
 kind: ClusterAdmission
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/name: test-cluster-admission
   name: test-cluster-admission


### PR DESCRIPTION
This PR sets the ArgoCD sync option `argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true` for all espejote CRs by default. This ensures that we prevent the cluster bootstrap from getting stuck for ArgoCD apps that try to deploy espejote resources before the espejote ArgoCD app is available.


## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
