### PR TITLE
Correctly set service account name for generated RBAC

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -91,7 +91,7 @@ local alerts = addKubernetesNameLabel({
 
 local serviceAccountName(name) =
   espejote.serviceAccountNameFromManagedResource(
-    params.managedResources[name].spec,
+    params.managedResources[name],
     'espejote-%s' % namespacedName(name).name
   );
 

--- a/tests/golden/resources/espejote/espejote/43_supplemental_role_my-namespace_copy-secret.yaml
+++ b/tests/golden/resources/espejote/espejote/43_supplemental_role_my-namespace_copy-secret.yaml
@@ -2,8 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: espejote-supplemental-admin-espejote-copy-secret
-  name: espejote:supplemental:admin:espejote-copy-secret
+    app.kubernetes.io/name: espejote-supplemental-admin-copy-configmap
+  name: espejote:supplemental:admin:copy-configmap
   namespace: my-namespace
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -11,15 +11,15 @@ roleRef:
   name: espejote:supplemental:my-namespace:copy-secret:admin
 subjects:
   - kind: ServiceAccount
-    name: espejote-copy-secret
+    name: copy-configmap
     namespace: my-namespace
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: espejote-supplemental-argocd-manager-espejote-copy-secret
-  name: espejote:supplemental:argocd-manager:espejote-copy-secret
+    app.kubernetes.io/name: espejote-supplemental-argocd-manager-copy-configmap
+  name: espejote:supplemental:argocd-manager:copy-configmap
   namespace: my-namespace
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -27,5 +27,5 @@ roleRef:
   name: espejote:supplemental:my-namespace:copy-secret:argocd-manager
 subjects:
   - kind: ServiceAccount
-    name: espejote-copy-secret
+    name: copy-configmap
     namespace: my-namespace

--- a/tests/golden/resources/espejote/espejote/60_mr_my-namespace_copy-secret.yaml
+++ b/tests/golden/resources/espejote/espejote/60_mr_my-namespace_copy-secret.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/name: espejote-copy-secret
+    app.kubernetes.io/name: copy-configmap
     managedresource.espejote.io/name: copy-secret
-  name: espejote-copy-secret
+  name: copy-configmap
   namespace: my-namespace
 ---
 apiVersion: espejote.io/v1alpha1

--- a/tests/golden/resources/espejote/espejote/60_mr_syn-espejote_with-sa-in-spec.yaml
+++ b/tests/golden/resources/espejote/espejote/60_mr_syn-espejote_with-sa-in-spec.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/name: espejote-with-sa-in-spec
+    app.kubernetes.io/name: sa-in-spec
     managedresource.espejote.io/name: with-sa-in-spec
-  name: espejote-with-sa-in-spec
+  name: sa-in-spec
   namespace: syn-espejote
 ---
 apiVersion: espejote.io/v1alpha1

--- a/tests/golden/resources/espejote/espejote/60_mr_syn-espejote_with-sa.yaml
+++ b/tests/golden/resources/espejote/espejote/60_mr_syn-espejote_with-sa.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/name: espejote-with-sa
+    app.kubernetes.io/name: sa-with
     managedresource.espejote.io/name: with-sa
-  name: espejote-with-sa
+  name: sa-with
   namespace: syn-espejote
 ---
 apiVersion: espejote.io/v1alpha1


### PR DESCRIPTION
This PR fixes the usage of the library function `serviceAccountNameFromManagedResource()` to correctly extract the service account name (if any) when generating RBAC resources.

Split out from #44

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
