### PR TITLE
Remove role name length assertions

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -129,17 +129,16 @@ local serviceAccount(mrName) = addKubernetesNameLabel({
 });
 
 local role(prefix, defaultNamespace) =
-  function(path) addKubernetesNameLabel({
+  function(path) {
     local nsName = namespacedName(path, namespace=defaultNamespace),
     local name = prefix + nsName.name,
-    assert std.length(name) <= 63 : "Resource name '%s' too long!" % name,
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'Role',
     metadata: {
       name: name,
       namespace: nsName.namespace,
     },
-  });
+  };
 
 local clusterRole(prefix) =
   function(path)
@@ -151,7 +150,7 @@ local clusterRole(prefix) =
     };
 
 local roleBinding(roleNamePrefix) =
-  function(roleNs, roleName, saNs, saName) addKubernetesNameLabel({
+  function(roleNs, roleName, saNs, saName) {
     local bindingName = std.join(':', std.prune([ 'esp', 'x', roleName, if saNs != roleNs then saNs, saName ])),
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'RoleBinding',
@@ -171,7 +170,7 @@ local roleBinding(roleNamePrefix) =
         namespace: saNs,
       },
     ],
-  });
+  };
 
 local clusterRoleBinding(roleNamePrefix) =
   function(roleName, saNs, saName)

--- a/lib/espejote.libsonnet
+++ b/lib/espejote.libsonnet
@@ -133,7 +133,6 @@ local generateRolesForManagedResource(manifest) =
           if clusterScoped(resource) || manifestMeta.namespace != resourceNs then manifestMeta.namespace,
           manifestMeta.name,
         ] + suffixes));
-        assert std.length(name) <= 63 : "Resource name '%s' too long!" % name;
         name,
     },
     rules: [

--- a/tests/golden/resources/espejote/espejote/43_supplemental_role_my-namespace_auto-roles-1.yaml
+++ b/tests/golden/resources/espejote/espejote/43_supplemental_role_my-namespace_auto-roles-1.yaml
@@ -1,8 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  labels:
-    app.kubernetes.io/name: esp-x-my-namespace-auto-roles-1-espejote-update-configmaps
   name: esp:x:my-namespace:auto-roles-1:espejote-update-configmaps
   namespace: my-namespace
 rules:
@@ -18,8 +16,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  labels:
-    app.kubernetes.io/name: esp-x-espejote-update-configmaps-espejote-auto-roles-1
   name: esp:x:espejote-update-configmaps:espejote-auto-roles-1
   namespace: my-namespace
 roleRef:

--- a/tests/golden/resources/espejote/espejote/43_supplemental_role_my-namespace_copy-configmap.yaml
+++ b/tests/golden/resources/espejote/espejote/43_supplemental_role_my-namespace_copy-configmap.yaml
@@ -1,8 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  labels:
-    app.kubernetes.io/name: esp-x-my-namespace-copy-configmap-configmaps
   name: esp:x:my-namespace:copy-configmap:configmaps
   namespace: a
 rules:
@@ -16,8 +14,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  labels:
-    app.kubernetes.io/name: esp-x-my-namespace-copy-configmap-configmaps
   name: esp:x:my-namespace:copy-configmap:configmaps
   namespace: b
 rules:
@@ -31,8 +27,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  labels:
-    app.kubernetes.io/name: esp-x-my-namespace-copy-configmap-configmaps
   name: esp:x:my-namespace:copy-configmap:configmaps
   namespace: my-namespace
 rules:
@@ -46,8 +40,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  labels:
-    app.kubernetes.io/name: esp-x-configmaps-my-namespace-espejote-copy-configmap
   name: esp:x:configmaps:my-namespace:espejote-copy-configmap
   namespace: a
 roleRef:
@@ -62,8 +54,6 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  labels:
-    app.kubernetes.io/name: esp-x-configmaps-my-namespace-espejote-copy-configmap
   name: esp:x:configmaps:my-namespace:espejote-copy-configmap
   namespace: b
 roleRef:
@@ -78,8 +68,6 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  labels:
-    app.kubernetes.io/name: esp-x-configmaps-espejote-copy-configmap
   name: esp:x:configmaps:espejote-copy-configmap
   namespace: my-namespace
 roleRef:

--- a/tests/golden/resources/espejote/espejote/43_supplemental_role_my-namespace_copy-secret.yaml
+++ b/tests/golden/resources/espejote/espejote/43_supplemental_role_my-namespace_copy-secret.yaml
@@ -1,8 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  labels:
-    app.kubernetes.io/name: esp-x-admin-copy-configmap
   name: esp:x:admin:copy-configmap
   namespace: my-namespace
 roleRef:
@@ -17,8 +15,6 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  labels:
-    app.kubernetes.io/name: esp-x-argocd-manager-copy-configmap
   name: esp:x:argocd-manager:copy-configmap
   namespace: my-namespace
 roleRef:

--- a/tests/golden/resources/espejote/espejote/44_supplemental_cluster_role_my-namespace_copy-configmap.yaml
+++ b/tests/golden/resources/espejote/espejote/44_supplemental_cluster_role_my-namespace_copy-configmap.yaml
@@ -1,8 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  labels:
-    app.kubernetes.io/name: esp-x-my-namespace-copy-configmap-namespace
   name: esp:x:my-namespace:copy-configmap:namespace
 rules:
   - apiGroups:
@@ -15,8 +13,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  labels:
-    app.kubernetes.io/name: esp-x-namespace-my-namespace-espejote-copy-configmap
   name: esp:x:namespace:my-namespace:espejote-copy-configmap
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Kubernetes actually doesn't restrict role/clusterrole name length. The actual error I saw previously was that the value of `app.kubernetes.io/name` can't exceed 63 characters.

For better UX, we remove the name length assertions again and instead drop the `app.kubernetes.io/name` label from the supplemental roles and rolebindings since that label isn't really required anyway.

Follow-up for #44 


## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
